### PR TITLE
fix: invalid signature seals

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -97,7 +97,7 @@ export class CertiMintValidation {
     this.apiKey = apiKey;
   }
 
-  public async resolveSeal(seal: ISeal): Promise<ISeal> {
+  public async updateSeal(seal: ISeal): Promise<ISeal> {
     seal.signatures = await this.resolveSignatures(seal.signatures);
     if (seal.signinvites) {
       seal.signinvites = await this.resolveSignInvites(seal.signinvites);

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -448,6 +448,7 @@ export class CertiMintValidation {
         }
       }
     }
+
     return signInvites;
   }
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -21,9 +21,9 @@ export enum DataType {
 }
 
 export enum SealStatus {
-  STATUS_CONFIRMED = 'confirmed',
-  STATUS_FAILED = 'failed',
-  STATUS_PENDING = 'pending',
+  CONFIRMED = 'confirmed',
+  FAILED = 'failed',
+  PENDING = 'pending',
 }
 
 export interface ISeal {
@@ -107,7 +107,7 @@ export class CertiMintValidation {
 
     const validationStatus = await this.validateSeal(seal, options);
 
-    return hash === seal.dataHash ? validationStatus : SealStatus.STATUS_FAILED;
+    return hash === seal.dataHash ? validationStatus : SealStatus.FAILED;
   }
 
   public async validateSeal(
@@ -124,21 +124,21 @@ export class CertiMintValidation {
     const validSignInvites = await this.validateSignInvites(seal.signinvites);
 
     if (
-      validSignatures === SealStatus.STATUS_FAILED ||
-      validSignInvites === SealStatus.STATUS_FAILED ||
+      validSignatures === SealStatus.FAILED ||
+      validSignInvites === SealStatus.FAILED ||
       !validAnchors
     ) {
-      return SealStatus.STATUS_FAILED;
+      return SealStatus.FAILED;
     }
 
     if (
-      validSignatures === SealStatus.STATUS_PENDING ||
-      validSignInvites === SealStatus.STATUS_PENDING
+      validSignatures === SealStatus.PENDING ||
+      validSignInvites === SealStatus.PENDING
     ) {
-      return SealStatus.STATUS_PENDING;
+      return SealStatus.PENDING;
     }
 
-    return SealStatus.STATUS_FAILED;
+    return SealStatus.FAILED;
   }
 
   private async hashForData(
@@ -282,7 +282,7 @@ export class CertiMintValidation {
   private async validateSignatures(
     signatures: ISignatures
   ): Promise<SealStatus> {
-    let isValid = SealStatus.STATUS_CONFIRMED;
+    let isValid = SealStatus.CONFIRMED;
     for (const protocol of Object.keys(signatures)) {
       for (const address of Object.keys(signatures[protocol])) {
         // This should technically not be neccessary since we only anchor signatures on Ethereum
@@ -296,15 +296,15 @@ export class CertiMintValidation {
           if (tx) {
             if (tx.data === this.addHexPrefix(signature.signature)) {
               isValid =
-                isValid === SealStatus.STATUS_CONFIRMED
-                  ? SealStatus.STATUS_CONFIRMED
+                isValid === SealStatus.CONFIRMED
+                  ? SealStatus.CONFIRMED
                   : isValid;
             }
 
-            return SealStatus.STATUS_FAILED;
+            return SealStatus.FAILED;
           }
 
-          isValid = SealStatus.STATUS_PENDING;
+          isValid = SealStatus.PENDING;
         }
       }
     }
@@ -315,7 +315,7 @@ export class CertiMintValidation {
   private async validateSignInvites(
     signInvites: ISignInvites
   ): Promise<SealStatus> {
-    let isValid = SealStatus.STATUS_CONFIRMED;
+    let isValid = SealStatus.CONFIRMED;
 
     if (signInvites && signInvites.anchors) {
       const signInviteAnchors = signInvites.anchors;
@@ -333,13 +333,13 @@ export class CertiMintValidation {
                 tx.data === this.addHexPrefix(signInvite.merkleRoot);
 
               isValid =
-                isValid === SealStatus.STATUS_CONFIRMED
-                  ? SealStatus.STATUS_CONFIRMED
+                isValid === SealStatus.CONFIRMED
+                  ? SealStatus.CONFIRMED
                   : isValid;
             }
 
             if (!tx) {
-              isValid = SealStatus.STATUS_PENDING;
+              isValid = SealStatus.PENDING;
             }
             const merkleTools = new MerkleTools({
               hashType: 'SHA3-512',
@@ -357,7 +357,7 @@ export class CertiMintValidation {
             }
 
             if (!validProof || !signInvite.exists) {
-              return SealStatus.STATUS_FAILED;
+              return SealStatus.FAILED;
             }
           }
         }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -97,17 +97,35 @@ export class CertiMintValidation {
     seal: ISeal,
     data: string,
     dataType: DataType,
-    bitcoinUrl: string = 'https://api.blockcypher.com/v1/btc/main'
-  ): Promise<SealStatus> {
+    ethereumUrl?: string, // TODO: this should be removed since this is never used, but this will break legacy systems
+    bitcoinUrl: string = 'https://api.blockcypher.com/v1/btc/main',
+    giveStatusBack?: boolean // add backwards compatibility
+  ): Promise<SealStatus | boolean> {
     const hash = await this.hashForData(data, dataType);
-    return hash === seal.dataHash && this.validateSeal(seal, bitcoinUrl);
+
+    const validationStatus = await this.validateSeal(
+      seal,
+      bitcoinUrl,
+      '',
+      true
+    );
+
+    if (giveStatusBack) {
+      return hash === seal.dataHash
+        ? validationStatus
+        : SealStatus.STATUS_FAILED;
+    }
+    return (
+      hash === seal.dataHash && validationStatus !== SealStatus.STATUS_FAILED
+    );
   }
 
   public async validateSeal(
     seal: ISeal,
     ethereumUrl?: string, // TODO: this should be removed since this is never used, but this will break legacy systems
-    bitcoinUrl: string = 'https://api.blockcypher.com/v1/btc/main'
-  ): Promise<SealStatus> {
+    bitcoinUrl: string = 'https://api.blockcypher.com/v1/btc/main',
+    giveStatusBack?: boolean // add backwards compatibility
+  ): Promise<SealStatus | boolean> {
     const validAnchors = await this.validateAnchors(
       seal.anchors,
       seal.dataHash,
@@ -117,22 +135,29 @@ export class CertiMintValidation {
     const validSignatures = await this.validateSignatures(seal.signatures);
     const validSignInvites = await this.validateSignInvites(seal.signinvites);
 
-    if (
-      validSignatures === SealStatus.STATUS_FAILED ||
-      validSignInvites === SealStatus.STATUS_FAILED ||
-      !validAnchors
-    ) {
+    if (giveStatusBack) {
+      if (
+        validSignatures === SealStatus.STATUS_FAILED ||
+        validSignInvites === SealStatus.STATUS_FAILED ||
+        !validAnchors
+      ) {
+        return SealStatus.STATUS_FAILED;
+      }
+
+      if (
+        validSignatures === SealStatus.STATUS_PENDING ||
+        validSignInvites === SealStatus.STATUS_PENDING
+      ) {
+        return SealStatus.STATUS_PENDING;
+      }
+
       return SealStatus.STATUS_FAILED;
     }
 
-    if (
-      validSignatures === SealStatus.STATUS_PENDING ||
-      validSignInvites === SealStatus.STATUS_PENDING
-    ) {
-      return SealStatus.STATUS_PENDING;
-    }
-
-    return validAnchors && validSignatures && validSignInvites;
+    return (
+      validSignatures !== SealStatus.STATUS_FAILED &&
+      validSignInvites !== SealStatus.STATUS_FAILED
+    );
   }
 
   private async hashForData(


### PR DESCRIPTION
BREAKING CHANGE: replace separate `validateseal` & `validateSealAndData` function parameters with an object
BREAKING CHANGE: `validateseal` & `validateSealAndData` now return a status instead of a boolean
feat: you can now update your current seal receipt with the latest status thanks to the `updateSeal` function